### PR TITLE
Only split on first / for ECR name

### DIFF
--- a/ecr_tag_resource/out.py
+++ b/ecr_tag_resource/out.py
@@ -69,7 +69,7 @@ def out_(source_dir, stdin):
     new_tag = get_contents_or_value(source_dir, new_tag)
     repository = get_contents_or_value(source_dir, repository)
 
-    repository_name = repository.split('/')[-1]
+    repository_name = repository.split('/',1)[-1]
     account_id = repository.split('.')[0]
 
     ecr = boto3.client('ecr', get_region())


### PR DESCRIPTION
Some ECR Images may have names containing a / character e.g. team-name/service. This change looks at splitting only on the first / it finds. (at the end of the ECR url.